### PR TITLE
My computer cannot use BrightnessKeys to adjust the brightness of the screen?

### DIFF
--- a/BrightnessKeys/BrightnessKeys.cpp
+++ b/BrightnessKeys/BrightnessKeys.cpp
@@ -111,7 +111,7 @@ void BrightnessKeys::getBrightnessPanel() {
         //
         // Some vendors just won't follow the specs and update their code
         //
-        if (strncmp(_panel->getName(), "DD02", strlen("DD02"))) {
+        if (_panel == nullptr || strncmp(_panel->getName(), "DD02", strlen("DD02"))) {
             auto fallbackPanel = info->videoBuiltin->childFromPath("DD02", gIODTPlane);
             if (fallbackPanel != nullptr) {
                 _panelFallback = getAcpiDevice(fallbackPanel);


### PR DESCRIPTION
Computer model: YOGA 9 15IMH5
System version: 13.4.1 (22F82)
BrightnessKeys version: latest version
Details: My computer adjusts the brightness of the computer screen through F11 and F12, but after configuring the plugin, it still cannot adjust the brightness.
I suspect it is due to the issue with DSDT. If I do not configure SSDT through "_QXX", I will not be able to adjust the brightness. The current segment for adjusting screen brightness code on DSDT is like this. How do I need to modify it to use the BrightnessKeys plugin?
```asl
Scope (_SB.PCI0.LPCB.EC0)
{
        Name (ACIO, Zero)
        Name (DCIO, Zero)
        Method (_Q1C, 0, NotSerialized)  // _Qxx: EC Query, xx=0x00-0xFF
        {
            P80H = 0x1C
            ADBG ("Brightness Up")
            Local0 = (SWBL & One)
            If ((Local0 == Zero))
            {
                Local1 = (SWBL | One)
                SWBL = Local1
            }
            Else
            {
                Acquire (MSGF, 0xFFFF)
                BRTN (0x86)
                Release (MSGF)
            }

            If ((OSYS == 0x07D9))
            {
                Sleep (0x64)
                VP1D |= 0x10
                Notify (VPC0, 0x80) // Status Change
            }
        }

        Method (_Q1D, 0, NotSerialized)  // _Qxx: EC Query, xx=0x00-0xFF
        {
            ADBG ("Brightness Down")
            P80H = 0x1D
            Local0 = (^^^GFX0.CBLV & 0xFF)
            If ((Local0 <= One))
            {
                Local1 = (SWBL & 0xFE)
                SWBL = Local1
            }

            Acquire (MSGF, 0xFFFF)
            BRTN (0x87)
            Release (MSGF)
            If ((OSYS == 0x07D9))
            {
                Sleep (0x64)
                VP1D |= 0x10
                Notify (VPC0, 0x80) // Status Change
            }
        }
}
```

Specific DSDT information：
[System DSDT.zip](https://github.com/sunbos/BrightnessKeys/files/11991423/System.DSDT.zip)
